### PR TITLE
Fix memory leak introduced in 21f7601

### DIFF
--- a/ios/ReactNativeCameraKit/CameraView.swift
+++ b/ios/ReactNativeCameraKit/CameraView.swift
@@ -134,12 +134,12 @@ public class CameraView: UIView {
         #if !targetEnvironment(macCatalyst)
         // Create a new capture event interaction with a handler that captures a photo.
         if #available(iOS 17.2, *) {
-            let interaction = AVCaptureEventInteraction { event in
+            let interaction = AVCaptureEventInteraction { [weak self] event in
                 // Capture a photo on "press up" of a hardware button.
                 if event.phase == .began {
-                    self.onCaptureButtonPressIn?(nil)
+                    self?.onCaptureButtonPressIn?(nil)
                 } else if event.phase == .ended {
-                    self.onCaptureButtonPressOut?(nil)
+                    self?.onCaptureButtonPressOut?(nil)
                 }
             }
             // Add the interaction to the view controller's view.


### PR DESCRIPTION
Self is accessed within AVCaptureEventInteraction closure, which is stored in eventInteraction class variable, creating a retain cycle Use [weak self] to break the cycle
https://github.com/teslamotors/react-native-camera-kit/commit/21f760117b8865cb1865001cf14a728087162e8d#diff-5011dc3d3aefd7b67661ffa11130868519526e31f62f630ebf6ddc2d7f714e09R128-R135

## Summary

<!--
  1. Explain the **motivation** for making this change.
     What existing problem does the pull request solve?
  2. If you are fixing a bug, make sure there is an open ticket for it
-->

## How did you test this change?

<!--
  1. Test your finished branch/PR on iOS and Android.
     Demonstrate the code is solid with screen shots of both platforms.
  If you leave this empty, your PR will very likely be closed.
-->
